### PR TITLE
Fix mping doesn't work in MACOSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+# RustRover(JetBrains)
+.idea

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::io::Read;
+use std::io::{Read, ErrorKind};
 use std::net::{IpAddr, SocketAddr};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -147,11 +147,8 @@ pub fn ping(
         let size = match socket2.read(&mut buffer) {
             Ok(n) => n,
             Err(e) => {
-                if let Some(err_code) = e.raw_os_error() {
-                    if err_code == 11 {
-                        // { code: 11, kind: WouldBlock, message: "Resource temporarily unavailable" }
-                        continue;
-                    }
+                if e.kind() == ErrorKind::WouldBlock {
+                    continue;
                 }
                 error!("Error in read: {:?}", &e);
 


### PR DESCRIPTION
Currently, we hardcode the EAGAIN(11) errno check when reading the socket which is NOT always the same in different platforms(for example, MACOS is 35). So it'd be better to use ErrorKind::WouldBlock instead of the hardcode number.

Before applying this patch:

```shell
❯ sudo ./target/debug/mping -r 5 8.8.8.8
10:40:37 [INFO] 8.8.8.8: sent:5, recv:5,  loss rate: 0.00%, latency: 12.05ms
10:40:37 [ERROR] Error in read: Os { code: 35, kind: WouldBlock, message: "Resource temporarily unavailable" }
```